### PR TITLE
Allow @hollowverse/common to be bundled with Webpack

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -56,5 +56,9 @@ module.exports = {
     ),
     ...ifProd([new BabelMinifyPlugin()]),
   ],
-  externals: [nodeExternals()],
+  externals: [
+    nodeExternals({
+      whitelist: ['@hollowverse/common'],
+    }),
+  ],
 };


### PR DESCRIPTION
In order to be compatible with Node.js 6.10, `@hollowverse/common` helpers must be transpiled.