### PR TITLE
Do not use `branch` query string parameter in tested URLs

### DIFF
--- a/src/runReporters.ts
+++ b/src/runReporters.ts
@@ -22,8 +22,8 @@ import { writeFile } from './helpers/writeFile';
 export const runReporters: Handler = async (_event, _context, done) => {
   try {
     const urls = [
-      'https://hollowverse.com/?branch=master',
-      'https://hollowverse.com/Tom_Hanks?branch=master',
+      'https://hollowverse.com',
+      'https://hollowverse.com/Tom_Hanks',
     ];
     const dateStr = formatDate(new Date(), 'YYYY-MM-DD');
 


### PR DESCRIPTION
Setting `branch` will bypass CF edge cache and always cause a full roundtrip to the origin server. This does not reflect the actual user experience.